### PR TITLE
allow setter functions to be named like `With.name` `With.anotherField`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ module RecordSetter exposing (..)
 
 
 s_f1 : a -> { b | f1 : a } -> { b | f1 : a }
-s_f1 value record =
-    { record | f1 = value }
+s_f1 value__ record__ =
+    { record__ | f1 = value__ }
 
 
 s_f2 : a -> { b | f2 : a } -> { b | f2 : a }
-s_f2 value record =
-    { record | f2 = value }
+s_f2 value__ record__ =
+    { record__ | f2 = value__ }
 
 ...
 ```

--- a/index.js
+++ b/index.js
@@ -32,11 +32,13 @@ module ${moduleName} exposing (..)
 `;
 }
 
-function setterDefinition(recordFieldIdentifier) {
-  return `s_${recordFieldIdentifier} : a -> { b | ${recordFieldIdentifier} : a } -> { b | ${recordFieldIdentifier} : a }
-s_${recordFieldIdentifier} value record =
-    { record | ${recordFieldIdentifier} = value }
+function setterDefinition(prefix) {
+  return function(recordFieldIdentifier) {
+    return `${prefix}${recordFieldIdentifier} : a -> { b | ${recordFieldIdentifier} : a } -> { b | ${recordFieldIdentifier} : a }
+${prefix}${recordFieldIdentifier} value__ record__ =
+    { record__ | ${recordFieldIdentifier} = value__ }
 `;
+  }
 }
 
 const cwd = process.cwd();
@@ -46,10 +48,10 @@ function reducePerFile(identifierSet, filepath) {
   return sourceToIdentifiers(source, identifierSet);
 }
 
-function generate(filepaths = [], moduleName = "RecordSetter") {
+function generate(filepaths = [], moduleName = "RecordSetter", prefix = "s_") {
   const uniqIdentifiers = [filepaths].flat().reduce(reducePerFile, new Set());
   const sortedUniqIdentifiers = [...uniqIdentifiers].sort();
-  const setters = sortedUniqIdentifiers.map(setterDefinition);
+  const setters = sortedUniqIdentifiers.map(setterDefinition(prefix));
   return [moduleDeclaration(moduleName), ...setters].join("\n\n");
 }
 

--- a/setem.js
+++ b/setem.js
@@ -21,6 +21,10 @@ program
     "Set Elm src directory to write generated file to. Defaults to current working directory"
   )
   .option(
+    "--prefix <function prefix>",
+    "Set prefix of generated functions. Defaults to `s_`"
+  )
+  .option(
     "--module <moduleName>",
     `Set generated module name (also, file name). Defaults to \`RecordSetter\`.
 Must be fully qualified
@@ -32,9 +36,10 @@ Must be fully qualified
 
 function mainAction(args, options) {
   const module = options.module || "RecordSetter";
+  const prefix = options.prefix === undefined ? "s_" : options.prefix;
   const paths = [...new Set(expandDirs(args))];
   if (options.verbose) for (const path of paths) fileLoaded(path);
-  const generated = generate(paths, module);
+  const generated = generate(paths, module, prefix);
 
   if (options.stdout) {
     console.log(generated);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,28 +7,28 @@ module RecordSetter exposing (..)
 
 
 s_f1 : a -> { b | f1 : a } -> { b | f1 : a }
-s_f1 value record =
-    { record | f1 = value }
+s_f1 value__ record__ =
+    { record__ | f1 = value__ }
 
 
 s_f2 : a -> { b | f2 : a } -> { b | f2 : a }
-s_f2 value record =
-    { record | f2 = value }
+s_f2 value__ record__ =
+    { record__ | f2 = value__ }
 
 
 s_f3 : a -> { b | f3 : a } -> { b | f3 : a }
-s_f3 value record =
-    { record | f3 = value }
+s_f3 value__ record__ =
+    { record__ | f3 = value__ }
 
 
 s_f3_f1 : a -> { b | f3_f1 : a } -> { b | f3_f1 : a }
-s_f3_f1 value record =
-    { record | f3_f1 = value }
+s_f3_f1 value__ record__ =
+    { record__ | f3_f1 = value__ }
 
 
 s_f3_f2 : a -> { b | f3_f2 : a } -> { b | f3_f2 : a }
-s_f3_f2 value record =
-    { record | f3_f2 = value }
+s_f3_f2 value__ record__ =
+    { record__ | f3_f2 = value__ }
 `;
 
 test("generate from RecordDefAndExpr", () => {
@@ -63,18 +63,18 @@ module RecordSetter exposing (..)
 
 
 s_f1 : a -> { b | f1 : a } -> { b | f1 : a }
-s_f1 value record =
-    { record | f1 = value }
+s_f1 value__ record__ =
+    { record__ | f1 = value__ }
 
 
 s_f2 : a -> { b | f2 : a } -> { b | f2 : a }
-s_f2 value record =
-    { record | f2 = value }
+s_f2 value__ record__ =
+    { record__ | f2 = value__ }
 
 
 s_f3 : a -> { b | f3 : a } -> { b | f3 : a }
-s_f3 value record =
-    { record | f3 = value }
+s_f3 value__ record__ =
+    { record__ | f3 = value__ }
 `);
 });
 
@@ -87,17 +87,17 @@ module RecordSetter exposing (..)
 
 
 s_f1 : a -> { b | f1 : a } -> { b | f1 : a }
-s_f1 value record =
-    { record | f1 = value }
+s_f1 value__ record__ =
+    { record__ | f1 = value__ }
 
 
 s_f2 : a -> { b | f2 : a } -> { b | f2 : a }
-s_f2 value record =
-    { record | f2 = value }
+s_f2 value__ record__ =
+    { record__ | f2 = value__ }
 
 
 s_f3 : a -> { b | f3 : a } -> { b | f3 : a }
-s_f3 value record =
-    { record | f3 = value }
+s_f3 value__ record__ =
+    { record__ | f3 = value__ }
 `);
 });


### PR DESCRIPTION
when used with options: `--prefix '' --module With`

```elm
import With

increment model =
    model
        |> With.counter (model.counter + 1)

gotName s =
    Maybe.map (With.name s) maybeUser
```

also added `__` suffix to variable names to better avoid name conflicts