### PR TITLE
fix: use pretest instead of postinstall for elm make

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setem",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Set'em: Elm record setter generator",
   "repository": {
     "url": "https://github.com/ymtszw/setem"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "readme-md-generator": "^1.0.0"
   },
   "scripts": {
-    "postinstall": "cd src/fixtures/elm-spa-example/ && ../../../node_modules/.bin/elm make src/Main.elm --output elm.js",
+    "pretest": "cd src/fixtures/elm-spa-example/ && ../../../node_modules/.bin/elm make src/Main.elm --output elm.js",
     "setem": "src/setem.js",
     "test": "jest",
     "test:cli": "src/setem.test.sh"


### PR DESCRIPTION
Needs `yarn deprecate` for 0.3.0
