### PR TITLE
Exclude generated file itself. More tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,16 +19,21 @@ module.exports = {
  * @param {string} moduleName Module name to render. Defaults to "RecordSetter"
  * @param {string} prefix Function prefix. Defaults to "s_"
  * @param {string} elmJsonFile Path to elm.json file. If not given, it does not generate setters from dependencies
+ * @param {boolean} hasExplicitPaths If `true`, it does not generate setters from dependencies. (For backward compatibility)
  * @returns string
  */
 function generate(
-  filepaths = [],
+  filepaths,
   moduleName = "RecordSetter",
   prefix = "s_",
-  elmJsonFile = null
+  elmJsonFile = null,
+  hasExplicitPaths
 ) {
   const uniqIdentifiers = [filepaths].flat().reduce(reducePerFile, new Set());
-  const dependencyIdentifiers = collectIdentifiersFromDependencies(elmJsonFile);
+  const dependencyIdentifiers = collectIdentifiersFromDependencies(
+    elmJsonFile,
+    hasExplicitPaths
+  );
   const sortedUniqIdentifiers = [
     ...new Set([...uniqIdentifiers, ...dependencyIdentifiers]),
   ].sort();
@@ -128,8 +133,8 @@ function expandDirs(paths) {
   });
 }
 
-function collectIdentifiersFromDependencies(elmJsonFile) {
-  if (elmJsonFile) {
+function collectIdentifiersFromDependencies(elmJsonFile, hasExplicitPaths) {
+  if (!hasExplicitPaths && elmJsonFile) {
     const dependencies = resolveDependencies(elmJsonFile);
     const cacheFile = dependencyIdentifierCacheFile(elmJsonFile, dependencies);
     return getIdentifiersAndEnsureCache(dependencies, cacheFile);

--- a/src/setem.js
+++ b/src/setem.js
@@ -42,10 +42,17 @@ Defaults to ./elm.json`
 function mainAction(args, options) {
   const module = options.module || "RecordSetter";
   const prefix = options.prefix || "s_";
-  const elmJsonFile = options.elmJson; // Can be undefined; see resolvePaths() and other functions for default behavior
+  const elmJsonFile = options.elmJson || "./elm.json";
+  const hasExplicitPaths = args.length !== 0;
   const paths = resolvePaths(args, elmJsonFile);
   if (options.verbose) for (const path of paths) fileLoaded(path);
-  const generated = generate(paths, module, prefix, elmJsonFile);
+  const generated = generate(
+    paths,
+    module,
+    prefix,
+    elmJsonFile,
+    hasExplicitPaths
+  );
 
   if (options.stdout) {
     console.log(generated);

--- a/src/setem.test.sh
+++ b/src/setem.test.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 #
 
 
-# Should generate from explicit source file
+# Should generate from a single source file
   src/setem.js src/fixtures/RecordDefAndExpr.elm
   diff -u RecordSetter.elm src/fixtures/minimal-cli-result && rm RecordSetter.elm
 
@@ -42,6 +42,7 @@ set -euo pipefail
 # Should generate to directory
   src/setem.js --output src/ src/fixtures/*.elm
   diff -u src/RecordSetter.elm src/fixtures/minimal-cli-result && rm src/RecordSetter.elm
+
 
 # Should NOT include generated file itself (must be idempotent)
   src/setem.js --verbose --output src/fixtures/ src/fixtures/*.elm > invocation-log.first

--- a/src/setem.test.sh
+++ b/src/setem.test.sh
@@ -1,14 +1,65 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Generate from explicit source file
-src/setem.js src/fixtures/RecordDefAndExpr.elm
-diff RecordSetter.elm src/fixtures/minimal-cli-result
 
-# Generate from multiple source files
-src/setem.js src/fixtures/RecordDefAndExpr.elm src/fixtures/OnlyRecordDef.elm
-diff RecordSetter.elm src/fixtures/minimal-cli-result
+#    ______   __        ______          __                            __
+#   /      \ /  |      /      |        /  |                          /  |
+#  /$$$$$$  |$$ |      $$$$$$/        _$$ |_     ______    _______  _$$ |_
+#  $$ |  $$/ $$ |        $$ |        / $$   |   /      \  /       |/ $$   |
+#  $$ |      $$ |        $$ |        $$$$$$/   /$$$$$$  |/$$$$$$$/ $$$$$$/
+#  $$ |   __ $$ |        $$ |          $$ | __ $$    $$ |$$      \   $$ | __
+#  $$ \__/  |$$ |_____  _$$ |_         $$ |/  |$$$$$$$$/  $$$$$$  |  $$ |/  |
+#  $$    $$/ $$       |/ $$   |        $$  $$/ $$       |/     $$/   $$  $$/
+#   $$$$$$/  $$$$$$$$/ $$$$$$/          $$$$/   $$$$$$$/ $$$$$$$/     $$$$/
+#
 
-# Generate from full project with --elm-json option
-src/setem.js --elm-json src/fixtures/elm-spa-example/elm.json
-diff RecordSetter.elm src/fixtures/elm-spa-example-cli-result
+#
+# Call entrypoint script file (src/setem.js) with arguments,
+# then compare their result with fixtures using `diff`!
+#
+
+
+# Should generate from explicit source file
+  src/setem.js src/fixtures/RecordDefAndExpr.elm
+  diff -u RecordSetter.elm src/fixtures/minimal-cli-result && rm RecordSetter.elm
+
+
+# Should generate from multiple source files
+  src/setem.js src/fixtures/RecordDefAndExpr.elm src/fixtures/OnlyRecordDef.elm
+  diff -u RecordSetter.elm src/fixtures/minimal-cli-result && rm RecordSetter.elm
+
+
+# Should generate from multiple source files with glob
+  src/setem.js src/fixtures/*.elm
+  diff -u RecordSetter.elm src/fixtures/minimal-cli-result && rm RecordSetter.elm
+
+
+# Should generate to stdout
+  src/setem.js --stdout src/fixtures/*.elm |
+  diff --ignore-blank-lines -u - src/fixtures/minimal-cli-result
+
+
+# Should generate to directory
+  src/setem.js --output src/ src/fixtures/*.elm
+  diff -u src/RecordSetter.elm src/fixtures/minimal-cli-result && rm src/RecordSetter.elm
+
+
+# Should fail if elm.json is missing without option
+  if src/setem.js 1> /dev/null 2> /dev/null; then
+    echo "setem should have failed but succeeded"
+    exit 1
+  else
+    echo "Failed as expected"
+  fi
+
+
+# Should generate from full project without option
+  pushd src/fixtures/elm-spa-example
+    ../../../src/setem.js
+    diff -u RecordSetter.elm ../elm-spa-example-cli-result && rm RecordSetter.elm
+  popd
+
+
+# Should generate from full project with --elm-json option
+  src/setem.js --elm-json src/fixtures/elm-spa-example/elm.json
+  diff -u RecordSetter.elm src/fixtures/elm-spa-example-cli-result && rm RecordSetter.elm

--- a/src/setem.test.sh
+++ b/src/setem.test.sh
@@ -43,6 +43,14 @@ set -euo pipefail
   src/setem.js --output src/ src/fixtures/*.elm
   diff -u src/RecordSetter.elm src/fixtures/minimal-cli-result && rm src/RecordSetter.elm
 
+# Should NOT include generated file itself (must be idempotent)
+  src/setem.js --verbose --output src/fixtures/ src/fixtures/*.elm > invocation-log.first
+  diff -u src/fixtures/RecordSetter.elm src/fixtures/minimal-cli-result
+  src/setem.js --verbose --output src/fixtures/ src/fixtures/*.elm > invocation-log.second
+  diff -u src/fixtures/RecordSetter.elm src/fixtures/minimal-cli-result
+  diff -u invocation-log.first invocation-log.second
+  rm src/fixtures/RecordSetter.elm invocation-log.*
+
 
 # Should fail if elm.json is missing without option
   if src/setem.js 1> /dev/null 2> /dev/null; then


### PR DESCRIPTION
- test: more precise CLI test
- fix: properly handle explicit paths and not
- test: test exclusion of generated file itself
- feat: exclude generated file itself from source paths
- chore: comments and blank lines
